### PR TITLE
Add after_commit_transition_to

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: ruby
 rvm:
   - 2.1.2
-cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: ruby
 rvm:
   - 2.1.2
+before_install:
+  - gem install bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ PLATFORMS
 
 DEPENDENCIES
   ar_state_machine!
-  bundler (~> 1.12)
+  bundler (~> 1.3)
   rake (~> 10.0)
   rspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,32 @@
 PATH
   remote: .
   specs:
-    ar_state_machine (0.1.0)
-      activerecord (>= 4.0.0)
+    ar_state_machine (0.1.1)
+      activerecord (~> 4.2)
       timecop
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.6)
-      activesupport (= 4.2.6)
+    activemodel (4.2.10)
+      activesupport (= 4.2.10)
       builder (~> 3.1)
-    activerecord (4.2.6)
-      activemodel (= 4.2.6)
-      activesupport (= 4.2.6)
+    activerecord (4.2.10)
+      activemodel (= 4.2.10)
+      activesupport (= 4.2.10)
       arel (~> 6.0)
-    activesupport (4.2.6)
+    activesupport (4.2.10)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    arel (6.0.3)
-    builder (3.2.2)
+    arel (6.0.4)
+    builder (3.2.3)
+    concurrent-ruby (1.0.5)
     diff-lcs (1.2.5)
-    i18n (0.7.0)
-    json (1.8.3)
-    minitest (5.9.0)
+    i18n (0.9.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.10.3)
     rake (10.5.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -41,9 +41,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    thread_safe (0.3.5)
-    timecop (0.8.0)
-    tzinfo (1.2.2)
+    thread_safe (0.3.6)
+    timecop (0.9.1)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -56,4 +56,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.12.5
+   1.14.2

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ These use the [active record callback chain](http://guides.rubyonrails.org/v4.2/
   - `after_transition_to` runs on `after_update`
   - `after_commit_transition_to` runs on `after_commit, on: :update`
 
+Here are some rules of thumb to follow:
+
+  - `before_transition` - only if you need to be able to halt the transaction or you need to set a value on the model being transitioned. You can also use this to halt AR state machine callbacks but still allow the transaction to save (payment failure is a good example, we still want to save the failure).
+  - `after_transition` - only if you need to be able to halt the transaction - you'll need to do it with an exception as returning false does nothing here
+  - `after_commit_transition` - most of the time, background job queue, cache clearing and similar tasks, updating child records, etc
 
 ```ruby
   before_transition_to :second_state do |from, to|

--- a/README.md
+++ b/README.md
@@ -43,8 +43,15 @@ Simply define the state machine at the top of your model in the format below:
 
 This example indicates that first_state can transition to second_state or third_state but second_state can only transition to third_state which is then a dead end.
 
-Then add any before or after callbacks to fire on state changes.
-If a before_transition_to returns false any further ones will stop and the model will not save
+Then add any before, after and after_commit callbacks to fire on state changes.
+
+These use the [active record callback chain](http://guides.rubyonrails.org/v4.2/active_record_callbacks.html):
+
+  - `before_transition_to` runs on `before_update`
+    - returning false or raising an exception in here will halt the transaction stop running transitions
+  - `after_transition_to` runs on `after_update`
+  - `after_commit_transition_to` runs on `after_commit, on: :update`
+
 
 ```ruby
   before_transition_to :second_state do |from, to|
@@ -55,6 +62,9 @@ If a before_transition_to returns false any further ones will stop and the model
   end
   after_transition_to :second_state do |from, to|
     puts "doing an after transition #{self.state}"
+  end
+  after_commit_transition_to :second_state do |from, to|
+    puts "doing an after commit transition #{self.state}"
   end
 ```
 

--- a/ar_state_machine.gemspec
+++ b/ar_state_machine.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency('rspec')
-  spec.add_dependency "activerecord", ">= 4.0.0"
+  spec.add_dependency "activerecord", "~> 4.2"
   spec.add_dependency "timecop"
 end

--- a/ar_state_machine.gemspec
+++ b/ar_state_machine.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency('rspec')
   spec.add_dependency "activerecord", "~> 4.2"

--- a/lib/ar_state_machine.rb
+++ b/lib/ar_state_machine.rb
@@ -302,12 +302,12 @@ module ARStateMachine
 
     def run_before_transition_callbacks(to, model, from)
       callbacks = @before_transitions[to.to_sym]
-      return process_callbacks(to, model, from, callbacks) if callbacks
+      process_callbacks(to, model, from, callbacks) if callbacks
     end
 
     def run_after_transition_callbacks(to, model, from)
       callbacks = @after_transitions[to.to_sym]
-      return process_callbacks(to, model, from, callbacks) if callbacks
+      process_callbacks(to, model, from, callbacks) if callbacks
     end
   end
 end

--- a/lib/ar_state_machine/version.rb
+++ b/lib/ar_state_machine/version.rb
@@ -1,3 +1,3 @@
 module ARStateMachine
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/fake_active_record_model.rb
+++ b/spec/fake_active_record_model.rb
@@ -1,6 +1,6 @@
 class FakeActiveRecordModel
   # pretend to be an active record model
-  # this isn't a perfect way to test because I can't seperate the callbacks and 
+  # this isn't a perfect way to test because I can't seperate the callbacks and
   # test that if invalid the before's are called and the after's aren't
 
   include ActiveModel::Model
@@ -11,13 +11,13 @@ class FakeActiveRecordModel
 
   # override a few methods because this isn't valid to insert to the state change table - this isn't an AR model
   def self.has_many(what, options={}); end;
-  
-  define_model_callbacks :update, :initialize, :create
+
+  define_model_callbacks :update, :initialize, :create, :commit
 
 
   def self.create(params={})
     model = self.new(params)
-    model 
+    model
   end
 
   # Just check validity, and if so, trigger callbacks.
@@ -25,6 +25,7 @@ class FakeActiveRecordModel
     if valid?
       run_callbacks(:update) { true }
       id ||= rand(1000)
+      run_callbacks(:commit) { true }
       true
     else
       false
@@ -35,6 +36,7 @@ class FakeActiveRecordModel
     if valid?
       run_callbacks(:update) { true }
       id ||= rand(1000)
+      run_callbacks(:commit) { true }
       true
     else
       throw Exception self.errors


### PR DESCRIPTION
We've seen an increase in database deadlocks lately and in part this seems related to transaction size / time to commit. After thinking about it I realized that a ton of our `before_transition`/`after_transition` stuff doesn't need to happen inside of the transaction, especially the after_transition stuff for background job queue, cache clearing, updating child records and similar tasks. 

Here are some new rules to follow: 

- `before_transition` - only if you need to be able to halt the transaction or you need to set a value on the model being transitioned. You can also use this to halt AR state machine callbacks but still allow the transaction to save (payment failure is a good example, we still want to save the failure). 
- `after_transition` - only if you need to be able to halt the transaction - you'll need to do it with an exception as returning false does nothing here 
- `after_commit_transition` - most of the time, probably 95% of the `after_transition`'s we have today. 