### PR TITLE
Before/After/Etc Transition From 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ar_state_machine (0.1.1)
+    ar_state_machine (0.1.2)
       activerecord (~> 4.2)
       timecop
 
@@ -24,9 +24,9 @@ GEM
     builder (3.2.3)
     concurrent-ruby (1.0.5)
     diff-lcs (1.2.5)
-    i18n (0.9.0)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    minitest (5.10.3)
+    minitest (5.11.3)
     rake (10.5.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -43,7 +43,7 @@ GEM
     rspec-support (3.4.1)
     thread_safe (0.3.6)
     timecop (0.9.1)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
 
 PLATFORMS

--- a/README.md
+++ b/README.md
@@ -47,10 +47,14 @@ Then add any before, after and after_commit callbacks to fire on state changes.
 
 These use the [active record callback chain](http://guides.rubyonrails.org/v4.2/active_record_callbacks.html):
 
-  - `before_transition_to` runs on `before_update`
+**Note:** if you have multiple of the same transition type they execute in the order they are put in your model file.
+
+  - `before_transition_to`, `before_transition_from` run on `before_update`
     - returning false or raising an exception in here will halt the transaction stop running transitions
-  - `after_transition_to` runs on `after_update`
-  - `after_commit_transition_to` runs on `after_commit, on: :update`
+  - `after_transition_to`, `after_transition_from` run on `after_update`
+  - `after_commit_transition_to`, `after_commit_transition_from` run on `after_commit, on: :update`
+
+
 
 Here are some rules of thumb to follow:
 
@@ -70,6 +74,15 @@ Here are some rules of thumb to follow:
   end
   after_commit_transition_to :second_state do |from, to|
     puts "doing an after commit transition #{self.state}"
+  end
+  before_transition_from :second_state do |from, to|
+    puts "doing before transition from #{self.state}"
+  end
+  after_transition_from :second_state do |from, to|
+    puts "doing an after transition from #{self.state}"
+  end
+  after_commit_transition_from :second_state do |from, to|
+    puts "doing an after commit transition from #{self.state}"
   end
 ```
 

--- a/lib/ar_state_machine.rb
+++ b/lib/ar_state_machine.rb
@@ -121,9 +121,13 @@ module ARStateMachine
 
   module ClassMethods
     def setup(states)
-      @before_transitions ||= {}
-      @after_transitions ||= {}
-      @after_commit_transitions ||= {}
+      @before_transitions_to ||= {}
+      @after_transitions_to ||= {}
+      @after_commit_transitions_to ||= {}
+      @before_transitions_from ||= {}
+      @after_transitions_from ||= {}
+      @after_commit_transitions_from ||= {}
+      @all_callbacks ||= []
 
       states_sym = states.keys.map(&:to_sym)
 
@@ -220,13 +224,15 @@ module ARStateMachine
         to = [to]
       end
       to.each do |to_|
-        @before_transitions[to_.to_sym] ||= []
+        to_sym_ = to_.to_sym
+        @before_transitions_to[to_sym_] ||= []
         if !method.present?
-          method = "_before_transition_to_#{to_.to_sym}_#{@before_transitions[to_.to_sym].length}"
+          method = "_before_transition_to_#{to_}_#{@before_transitions_to[to_sym_].length}"
+          @all_callbacks.push method
           define_method method, block
         end
 
-        @before_transitions[to_.to_sym].push({method: method, rollback_on_failure: rollback_on_failure})
+        @before_transitions_to[to_sym_].push({method: method, rollback_on_failure: rollback_on_failure})
       end
       true
     end
@@ -236,13 +242,15 @@ module ARStateMachine
         to = [to]
       end
       to.each do |to_|
-        @after_transitions[to_.to_sym] ||= []
+        to_sym_ = to_.to_sym
+        @after_transitions_to[to_sym_] ||= []
         if !method.present?
-          method = "_after_transition_to_#{to_.to_sym}_#{@after_transitions[to_.to_sym].length}"
+          method = "_after_transition_to_#{to_}_#{@after_transitions_to[to_sym_].length}"
+          @all_callbacks.push method
           define_method method, block
         end
 
-        @after_transitions[to_.to_sym].push({method: method}) # AR doesn't do rollbacks for after_* callbacks
+        @after_transitions_to[to_.to_sym].push({method: method}) # AR doesn't do rollbacks for after_* callbacks
       end
       true
     end
@@ -252,18 +260,79 @@ module ARStateMachine
         to = [to]
       end
       to.each do |to_|
-        @after_commit_transitions[to_.to_sym] ||= []
+        to_sym_ = to_.to_sym
+        @after_commit_transitions_to[to_sym_] ||= []
         if !method.present?
-          method = "_after_commit_to_#{to_.to_sym}_#{@after_commit_transitions[to_.to_sym].length}"
+          method = "_after_commit_to_#{to_}_#{@after_commit_transitions_to[to_sym_].length}"
+          @all_callbacks.push method
           define_method method, block
         end
 
-        @after_commit_transitions[to_.to_sym].push({method: method})
+        @after_commit_transitions_to[to_sym_].push({method: method})
+      end
+      true
+    end
+
+    def before_transition_from(from, method=nil, rollback_on_failure=true, &block)
+      if from.class != Array
+        from = [from]
+      end
+      from.each do |from_|
+        from_sym = from_.to_sym
+        @before_transitions_from[from_sym] ||= []
+        if !method.present?
+          method = "_before_transition_from_#{from_}_#{@before_transitions_from[from_sym].length}"
+          @all_callbacks.push method
+          define_method method, block
+        end
+
+        @before_transitions_from[from_sym].push({method: method, rollback_on_failure: rollback_on_failure})
+      end
+      true
+    end
+
+    def after_transition_from(from, method=nil, &block)
+      if from.class != Array
+        from = [from]
+      end
+      from.each do |from_|
+        from_sym = from_.to_sym
+        @after_transitions_from[from_sym] ||= []
+        if !method.present?
+          method = "_after_transition_from_#{from_}_#{@after_transitions_from[from_sym].length}"
+          @all_callbacks.push method
+          define_method method, block
+        end
+
+        @after_transitions_from[from_sym].push({method: method}) # AR doesn't do rollbacks for after_* callbacks
+      end
+      true
+    end
+
+    def after_commit_transition_from(from, method=nil, &block)
+      if from.class != Array
+        from = [from]
+      end
+      from.each do |from_|
+        from_sym = from_.to_sym
+        @after_commit_transitions_from[from_sym] ||= []
+        if !method.present?
+          method = "_after_commit_from_#{from_}_#{@after_commit_transitions_from[from_sym].length}"
+          @all_callbacks.push method
+          define_method method, block
+        end
+
+        @after_commit_transitions_from[from_sym].push({method: method})
       end
       true
     end
 
     def process_callbacks(to, model, from, callbacks, ignore_response=false)
+      # make sure these are all in the right order if there are to and from callbacks
+      callbacks.sort_by! do |callback|
+        @all_callbacks.index(callback)
+      end
+
       callbacks.each do |callback|
         args = case model.method(callback[:method]).parameters.count
         when 1
@@ -296,18 +365,21 @@ module ARStateMachine
     end
 
     def run_after_commit_transition_callbacks(to, model, from)
-      callbacks = @after_commit_transitions[to.to_sym]
-      process_callbacks(to, model, from, callbacks, true) if callbacks
+      callbacks = @after_commit_transitions_to[to.to_sym]||[]
+      callbacks += @after_commit_transitions_from[from.to_sym]||[]
+      process_callbacks(to, model, from, callbacks, true) if callbacks.length > 0
     end
 
     def run_before_transition_callbacks(to, model, from)
-      callbacks = @before_transitions[to.to_sym]
-      process_callbacks(to, model, from, callbacks) if callbacks
+      callbacks = @before_transitions_to[to.to_sym]||[]
+      callbacks += @before_transitions_from[from.to_sym]||[]
+      process_callbacks(to, model, from, callbacks) if callbacks.length > 0
     end
 
     def run_after_transition_callbacks(to, model, from)
-      callbacks = @after_transitions[to.to_sym]
-      process_callbacks(to, model, from, callbacks) if callbacks
+      callbacks = @after_transitions_to[to.to_sym]||[]
+      callbacks += @after_transitions_from[from.to_sym]||[]
+      process_callbacks(to, model, from, callbacks) if callbacks.length > 0
     end
   end
 end

--- a/lib/ar_state_machine/version.rb
+++ b/lib/ar_state_machine/version.rb
@@ -1,3 +1,3 @@
 module ARStateMachine
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Add callbacks to trigger before/after/after_commit transition from a state #10

this will simplify a decent amount of our transitions.  specifically looking to do 

```
after_transition_from SELF_CHECKOUT_STATES do 
  user.clear_self_checkout_order
end
```