### PR TITLE
Don't Set state_by_id to nil

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ar_state_machine (0.1.5)
+    ar_state_machine (0.1.6)
       activerecord (~> 4.2)
       timecop
 

--- a/lib/ar_state_machine.rb
+++ b/lib/ar_state_machine.rb
@@ -132,7 +132,7 @@ module ARStateMachine
         overwrite = !(self.class.send("overwrite_#{self.state}_by_id") == false)
       end
       if self.send("#{self.state}_by_id").blank? or overwrite
-        self.send("#{self.state}_by_id=", self.last_edited_by_id)
+        self.send("#{self.state}_by_id=", self.last_edited_by_id) if self.last_edited_by_id.present?
       end
     end
   end

--- a/lib/ar_state_machine/version.rb
+++ b/lib/ar_state_machine/version.rb
@@ -1,3 +1,3 @@
 module ARStateMachine
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/spec/lib/state_machine_spec.rb
+++ b/spec/lib/state_machine_spec.rb
@@ -141,6 +141,16 @@ describe "StateMachine" do
     expect(test.make_second_state(5)).to be true
     expect(test.second_state_by_id).to eq(was)
   end
+
+  it "test setting value before hand then changing states perserves id" do
+    test = StateMachineTestClass.create
+    expect(test.second_state_by_id).to be_nil
+
+    test.second_state_by_id = 2
+    expect(test.make_second_state).to be true
+
+    expect(2).to eq(test.second_state_by_id)
+  end
 end
 
 class StateMachineTestClass < FakeActiveRecordModel


### PR DESCRIPTION
In some of the `wantable-2` tests, we do 
```
object.state_by_id = 5
object.make_state
```

Because its not saved, `state_by_id` is seen as nil, and saved as such. This change removes that problem. 

Another workaround for the problem listed above is to just pass in the user id doing the changing:
```
object.make_state(5)
```