### PR TITLE
AR State Machine Transition At 

### DIFF
--- a/lib/ar_state_machine.rb
+++ b/lib/ar_state_machine.rb
@@ -87,6 +87,7 @@ module ARStateMachine
     if self.skipped_transition and self.respond_to?("#{self.skipped_transition}_at=")
       self.send("#{self.skipped_transition}_at=", Time.now)
     end
+
     if self.respond_to?("#{self.state}_at=")
       overwrite = true
       if self.respond_to?("overwrite_#{self.state}_at")
@@ -95,7 +96,7 @@ module ARStateMachine
       elsif self.class.respond_to?("overwrite_#{self.state}_at")
         overwrite = !(self.class.send("overwrite_#{self.state}_at") == false)
       end
-      if self.send("#{self.state}_at").blank? or overwrite
+      if (self.send("#{self.state}_at").blank? or overwrite) and self.state_changed?
         self.send("#{self.state}_at=", Time.now)
       end
     end


### PR DESCRIPTION
Started with this...
![image](https://user-images.githubusercontent.com/7546321/43864004-083c5da0-9b24-11e8-92e8-1a17f1eb5764.png)
And after some stumbling around I realized there were 0 orders with `pre_collections_at > 30.days.ago`. Most of which had their state change to pre-collections months ago. I dug into logentries and was able to determine it was happening in `PreCollectionsBillingWorker.rb`. 

I ran through the code and there wasn't a single transition to pre-collections, so I looked more into what was happening in `order.make_billed` and realized it was updating the `pre_collections_at` date, on failure! 

This should fix the issue, I think, but who knows how much bad data is out there...

