### PR TITLE
Rails 5.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-  - 2.1.2
+  - 2.4.9
 before_install:
   - gem install bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    ar_state_machine (0.2.1)
-      activerecord (>= 4.2)
+    ar_state_machine (0.3.0)
+      activerecord (>= 5.0)
       timecop
 
 GEM
@@ -20,7 +20,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     diff-lcs (1.2.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)

--- a/ar_state_machine.gemspec
+++ b/ar_state_machine.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency('rspec')
-  spec.add_dependency "activerecord", ">= 4.2"
+  spec.add_dependency "activerecord", ">= 5.0"
   spec.add_dependency "timecop"
 end

--- a/lib/ar_state_machine.rb
+++ b/lib/ar_state_machine.rb
@@ -83,7 +83,8 @@ module ARStateMachine
   end
 
   def do_state_change_before_callbacks
-    return false if self.class.run_before_transition_callbacks(self.state, self, old_state) == false
+    self.class.run_before_transition_callbacks(self.state, self, old_state)
+
     if self.skipped_transition and self.respond_to?("#{self.skipped_transition}_at=")
       self.send("#{self.skipped_transition}_at=", Time.now)
     end
@@ -260,7 +261,6 @@ module ARStateMachine
 
         @before_transitions_to[to_sym_].push({method: method, rollback_on_failure: rollback_on_failure})
       end
-      true
     end
 
     def after_transition_to(to, method=nil, &block)
@@ -278,7 +278,6 @@ module ARStateMachine
 
         @after_transitions_to[to_.to_sym].push({method: method}) # AR doesn't do rollbacks for after_* callbacks
       end
-      true
     end
 
     def after_commit_transition_to(to, method=nil, &block)
@@ -296,7 +295,6 @@ module ARStateMachine
 
         @after_commit_transitions_to[to_sym_].push({method: method})
       end
-      true
     end
 
     def before_transition_from(from, method=nil, rollback_on_failure=true, &block)
@@ -314,7 +312,6 @@ module ARStateMachine
 
         @before_transitions_from[from_sym].push({method: method, rollback_on_failure: rollback_on_failure})
       end
-      true
     end
 
     def after_transition_from(from, method=nil, &block)
@@ -332,7 +329,6 @@ module ARStateMachine
 
         @after_transitions_from[from_sym].push({method: method}) # AR doesn't do rollbacks for after_* callbacks
       end
-      true
     end
 
     def after_commit_transition_from(from, method=nil, &block)
@@ -350,7 +346,6 @@ module ARStateMachine
 
         @after_commit_transitions_from[from_sym].push({method: method})
       end
-      true
     end
 
     def process_callbacks(to, model, from, callbacks, ignore_response=false)
@@ -383,11 +378,10 @@ module ARStateMachine
             break # just exit THIS chain; not the whole rails callback chain
           else
             # rollback changes / cancel subsequent other callbacks
-            return false
+            throw :abort
           end
         end
       end
-      true
     end
 
     def run_after_commit_transition_callbacks(to, model, from)

--- a/lib/ar_state_machine/version.rb
+++ b/lib/ar_state_machine/version.rb
@@ -1,3 +1,3 @@
 module ARStateMachine
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/spec/lib/state_machine_spec.rb
+++ b/spec/lib/state_machine_spec.rb
@@ -44,10 +44,10 @@ describe "StateMachine" do
     expect(test.second_state_at).not_to be_nil
 
     expect(test.has_been_made_second_state?).to be true
-    expect{ test.has_been_made_fourth_state? }.to raise_error(NotImplementedError)
+    expect{ test.has_been_made_fifth_state? }.to raise_error(NotImplementedError)
   end
 
-  it "test does not overwrite previous state_at on transition fail" do
+  it "test does not change state_at on transition fail" do
     test = StateMachineTestClass.create
     expect(test.make_third_state).to be true
     expect(test.is_third_state?).to be true
@@ -58,6 +58,8 @@ describe "StateMachine" do
     expect(test.can_make_fourth_state?).to be true
     expect(test.make_fourth_state).to be false
     expect(test.callbacks_happened[:fourth_state][:before][:third_state]).to eq(1)
+    expect(test.is_third_state?).to be true
+    expect(test.fourth_state_at).to be_nil
     expect(test.third_state_at).to eq(was)
   end
 
@@ -168,7 +170,7 @@ describe "StateMachine" do
 end
 
 class StateMachineTestClass < FakeActiveRecordModel
-  attr_accessor :state, :second_state_at, :third_state_at, :second_state_by_id, :overwrite_second_state_at, :overwrite_second_state_by_id
+  attr_accessor :state, :second_state_at, :third_state_at, :fourth_state_at, :second_state_by_id, :overwrite_second_state_at, :overwrite_second_state_by_id
 
   def save
     super
@@ -217,7 +219,8 @@ class StateMachineTestClass < FakeActiveRecordModel
     first_state: [:second_state, :third_state],
     second_state: :third_state,
     third_state: :fourth_state,
-    fourth_state: []
+    fourth_state: [],
+    fifth_state: []
   })
   before_transition_to(:second_state) do |from, to|
     self.append_callback_happened(to.to_sym, from.to_sym, :before)


### PR DESCRIPTION
Handled this deprecation warning: 
> Returning `false` in Active Record and Active Model callbacks will not implicitly halt a callback chain in Rails 5.1. To explicitly halt the callback chain, please use `throw :abort` instead.