### PR TITLE
Fix Rollbacks in After Transitions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,28 @@
 PATH
   remote: .
   specs:
-    ar_state_machine (0.3.5)
+    ar_state_machine (0.3.6)
       activerecord (>= 5.2)
       timecop
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.4.3)
-      activesupport (= 7.0.4.3)
-    activerecord (7.0.4.3)
-      activemodel (= 7.0.4.3)
-      activesupport (= 7.0.4.3)
-    activesupport (7.0.4.3)
+    activemodel (7.0.7)
+      activesupport (= 7.0.7)
+    activerecord (7.0.7)
+      activemodel (= 7.0.7)
+      activesupport (= 7.0.7)
+    activesupport (7.0.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
-    i18n (1.13.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    minitest (5.18.0)
+    minitest (5.19.0)
     rake (13.0.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -37,7 +37,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    timecop (0.9.6)
+    timecop (0.9.8)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 

--- a/lib/ar_state_machine.rb
+++ b/lib/ar_state_machine.rb
@@ -299,8 +299,8 @@ module ARStateMachine
       end
     end
 
-    def after_transition_to(to, method = nil, &block)
-      append_transitions_callback(to, method || block, true, 'after_transition_to') do |state|
+    def after_transition_to(to, method = nil, rollback_on_failure: true, &block)
+      append_transitions_callback(to, method || block, rollback_on_failure, 'after_transition_to') do |state|
         @after_transitions_to[state] ||= []
       end
     end
@@ -317,8 +317,8 @@ module ARStateMachine
       end
     end
 
-    def after_transition_from(from, method = nil, &block)
-      append_transitions_callback(from, method || block, true, 'after_transition_from') do |state|
+    def after_transition_from(from, method = nil, rollback_on_failure: true, &block)
+      append_transitions_callback(from, method || block, rollback_on_failure, 'after_transition_from') do |state|
         @after_transitions_from[state] ||= []
       end
     end
@@ -355,7 +355,7 @@ module ARStateMachine
             if raise_not_throw
               # after save callback chain is halted like this
               # https://github.com/rails/rails/issues/33192
-              raise ActiveRecord::RecordInvalid, self
+              raise ActiveRecord::RecordInvalid, model
             else
               throw :abort
             end

--- a/lib/ar_state_machine/version.rb
+++ b/lib/ar_state_machine/version.rb
@@ -1,3 +1,3 @@
 module ARStateMachine
-  VERSION = "0.3.5"
+  VERSION = "0.3.6"
 end

--- a/spec/lib/state_machine_spec.rb
+++ b/spec/lib/state_machine_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require "fake_active_record_model"
+require "state_machine_test_class"
 require "timecop"
 
 describe "StateMachine" do
@@ -167,112 +167,30 @@ describe "StateMachine" do
 
     expect(2).to eq(test.second_state_by_id)
   end
-end
 
-class StateMachineTestClass < FakeActiveRecordModel
-  attr_accessor :state, :second_state_at, :third_state_at, :fourth_state_at, :second_state_by_id, :overwrite_second_state_at, :overwrite_second_state_by_id
+  it "test rollback_on_failure in before transition" do
+    test = StateMachineTestClass.create
 
-  def self.scope(_name, _block)
-    nil
+    thing = 'thing'
+
+    test.arbitrary_field = thing
+    expect(test.make_sixth_state).to be false
+    expect(test.is_first_state?).to be true   # state was rollback
+    expect(thing).to eq(test.arbitrary_field) # but other data was not
   end
 
-  def initialize(attributes)
-    super
-    @initial_state = self.states.first.first.to_s
-  end
+  it "test rollback_on_failure in after transition" do
+    test = StateMachineTestClass.create
 
-  def save
-    super
-    if valid?
-      @initial_state = self.state
-      true
-    else
-      false
-    end
-  end
+    thing = 'thing'
 
-  def save!
-    save
-    if valid?
-      true
-    else
-      raise Exception
-    end
-  end
-
-  def will_save_change_to_state?
-    self.state != @initial_state
-  end
-
-  alias_method :saved_change_to_state?, :will_save_change_to_state?
-
-  def changes_to_save
-    if will_save_change_to_state?
-      { state: [@initial_state, state] }
-    else
-      {}
-    end
-  end
-
-  alias_method :saved_changes, :changes_to_save
-
-  def reset
-    @initial_state = self.state
-  end
-
-  def save_state_change
-    nil
-  end
-
-  ## HERE begins the actual state machine implementation
-  include ARStateMachine
-
-  state_machine(
-    first_state: [:second_state, :third_state],
-    second_state: :third_state,
-    third_state: :fourth_state,
-    fourth_state: [],
-    fifth_state: []
-  )
-
-  before_transition_to(:second_state) do |from, to|
-    self.append_callback_happened(to.to_sym, from.to_sym, :before)
-  end
-
-  before_transition_to([:second_state]) do |from, to|
-    self.append_callback_happened(to.to_sym, from.to_sym, :before)
-  end
-
-  after_transition_to :second_state, :another_second_state_callback
-
-  before_transition_from(:second_state) do |from, to|
-    self.append_callback_happened(to.to_sym, from.to_sym, :before_from)
-  end
-
-  after_commit_transition_to :third_state do |from, to|
-    self.append_callback_happened(to.to_sym, from.to_sym, :after_commit)
-  end
-
-  def another_second_state_callback(from, to)
-    self.append_callback_happened(to.to_sym, from.to_sym, :after)
-  end
-
-  before_transition_to(:fourth_state) do |from, to|
-    self.append_callback_happened(to.to_sym, from.to_sym, :before)
-    self.errors.add(:state, "Cannot transition to fourth_state because I said so.")
-    false
-  end
-
-  # helper methods for the tests to know what callbacks occured
-  def callbacks_happened
-    @callbacks_happened
-  end
-
-  def append_callback_happened(to, from, kind)
-    @callbacks_happened ||= {}
-    @callbacks_happened[to]||={}
-    @callbacks_happened[to][kind]||={}
-    @callbacks_happened[to][kind][from] ||= 0
-    @callbacks_happened[to][kind][from] += 1
+    test.arbitrary_field = thing
+    expect(test.make_seventh_state).to be false
+    expect(test.is_first_state?).to be true   # state was rollback
+    expect(thing).to eq(test.arbitrary_field) # but other data was not
   end
 end
+
+
+
+

--- a/spec/state_machine_test_class.rb
+++ b/spec/state_machine_test_class.rb
@@ -1,0 +1,127 @@
+require "fake_active_record_model"
+
+class StateMachineTestClass < FakeActiveRecordModel
+  attr_accessor :state,
+                :second_state_at,
+                :third_state_at,
+                :fourth_state_at,
+                :second_state_by_id,
+                :overwrite_second_state_at,
+                :overwrite_second_state_by_id,
+                :arbitrary_field
+
+
+  def self.scope(_name, _block)
+    nil
+  end
+
+  def initialize(attributes)
+    super
+    @initial_state = self.states.first.first.to_s
+  end
+
+  def save
+    super
+    if valid?
+      @initial_state = self.state
+      true
+    else
+      false
+    end
+  end
+
+  def save!
+    save
+    if valid?
+      true
+    else
+      raise Exception
+    end
+  end
+
+  def will_save_change_to_state?
+    self.state != @initial_state
+  end
+
+  alias_method :saved_change_to_state?, :will_save_change_to_state?
+
+  def changes_to_save
+    if will_save_change_to_state?
+      { state: [@initial_state, state] }
+    else
+      {}
+    end
+  end
+
+  alias_method :saved_changes, :changes_to_save
+
+  def reset
+    @initial_state = self.state
+  end
+
+  def save_state_change
+    nil
+  end
+
+  ## HERE begins the actual state machine implementation
+  include ARStateMachine
+
+  state_machine(
+    first_state: [:second_state, :third_state, :sixth_state, :seventh_state],
+    second_state: :third_state,
+    third_state: :fourth_state,
+    fourth_state: [],
+    fifth_state: [],
+    sixth_state: [],
+    seventh_state: []
+  )
+
+  before_transition_to(:second_state) do |from, to|
+    self.append_callback_happened(to.to_sym, from.to_sym, :before)
+  end
+
+  before_transition_to([:second_state]) do |from, to|
+    self.append_callback_happened(to.to_sym, from.to_sym, :before)
+  end
+
+  after_transition_to :second_state, :another_second_state_callback
+
+  before_transition_from(:second_state) do |from, to|
+    self.append_callback_happened(to.to_sym, from.to_sym, :before_from)
+  end
+
+  after_commit_transition_to :third_state do |from, to|
+    self.append_callback_happened(to.to_sym, from.to_sym, :after_commit)
+  end
+
+  before_transition_to :sixth_state, rollback_on_failure: false do
+    false
+  end
+
+  after_transition_to :seventh_state, rollback_on_failure: false do
+    false
+  end
+
+  def another_second_state_callback(from, to)
+    self.append_callback_happened(to.to_sym, from.to_sym, :after)
+  end
+
+  before_transition_to(:fourth_state) do |from, to|
+    self.append_callback_happened(to.to_sym, from.to_sym, :before)
+    self.errors.add(:state, "Cannot transition to fourth_state because I said so.")
+    false
+  end
+
+  # helper methods for the tests to know what callbacks occured
+  def callbacks_happened
+    @callbacks_happened
+  end
+
+  def append_callback_happened(to, from, kind)
+    @callbacks_happened ||= {}
+    @callbacks_happened[to]||={}
+    @callbacks_happened[to][kind]||={}
+    @callbacks_happened[to][kind][from] ||= 0
+    @callbacks_happened[to][kind][from] += 1
+  end
+end


### PR DESCRIPTION
We generally put our important things that might require rollbacks in before transitions but sometimes an after transition wants to rollback too and as is this raises the exception:
```
UncaughtThrowError: uncaught throw :abort
```

Related: https://github.com/rails/rails/issues/33192

Since I was in there I changed the `rollback_on_failure` to a keyword argument and you'll see a similar set of changes in a PR in the primary repo too. After transitions did not have this so I added that as well.
