### PR TITLE
Log state_by_id even if not using make_state method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,40 @@
 PATH
   remote: .
   specs:
-    ar_state_machine (0.3.6)
+    ar_state_machine (0.3.7)
       activerecord (>= 5.2)
       timecop
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.7)
-      activesupport (= 7.0.7)
-    activerecord (7.0.7)
-      activemodel (= 7.0.7)
-      activesupport (= 7.0.7)
-    activesupport (7.0.7)
+    activemodel (7.1.1)
+      activesupport (= 7.1.1)
+    activerecord (7.1.1)
+      activemodel (= 7.1.1)
+      activesupport (= 7.1.1)
+      timeout (>= 0.4.0)
+    activesupport (7.1.1)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
+    base64 (0.1.1)
+    bigdecimal (3.1.4)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     diff-lcs (1.5.0)
+    drb (2.1.1)
+      ruby2_keywords
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    minitest (5.19.0)
+    minitest (5.20.0)
+    mutex_m (0.1.2)
     rake (13.0.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -37,7 +49,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
+    ruby2_keywords (0.0.5)
     timecop (0.9.8)
+    timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 

--- a/lib/ar_state_machine/version.rb
+++ b/lib/ar_state_machine/version.rb
@@ -1,3 +1,3 @@
 module ARStateMachine
-  VERSION = "0.3.6"
+  VERSION = "0.3.7"
 end

--- a/spec/lib/state_machine_spec.rb
+++ b/spec/lib/state_machine_spec.rb
@@ -150,12 +150,24 @@ describe "StateMachine" do
     expect(test.make_second_state(2)).to be true
 
     was = test.second_state_by_id
+    expect(was).to eq(2)
     test.overwrite_second_state_by_id = false
 
     test.state = StateMachineTestClass::FIRST_STATE
     expect(test.reset).to eq(StateMachineTestClass::FIRST_STATE)
     expect(test.make_second_state(5)).to be true
     expect(test.second_state_by_id).to eq(was)
+  end
+
+  it "calling update instead of make_state still saves by_id" do
+    test = StateMachineTestClass.create
+    expect(test.second_state_by_id).to be_nil
+
+    test.last_edited_by_id = 2
+    test.state = StateMachineTestClass::SECOND_STATE
+    expect(test.save).to be true
+
+    expect(2).to eq(test.second_state_by_id)
   end
 
   it "test setting value before hand then changing states perserves id" do


### PR DESCRIPTION
Now capturing and saving the state_by_id on any change to the state, previously it was only doing this if the caller explicitly used the make_state methods. 