### PR TITLE
Skipped Transitions Should Respect the "overwrite" timestamp flag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ar_state_machine (0.3.7)
+    ar_state_machine (0.3.8)
       activerecord (>= 5.2)
       timecop
 

--- a/lib/ar_state_machine.rb
+++ b/lib/ar_state_machine.rb
@@ -96,9 +96,7 @@ module ARStateMachine
     end
 
     if self.respond_to?("#{self.state}_at=")
-      overwrite = should_overwrite_timestamp?(self.state)
-
-      if (self.send("#{self.state}_at").blank? || overwrite)
+      if (self.send("#{self.state}_at").blank? || should_overwrite_timestamp?(self.state))
         self.send("#{self.state}_at=", Time.now)
       end
     end

--- a/lib/ar_state_machine/version.rb
+++ b/lib/ar_state_machine/version.rb
@@ -1,3 +1,3 @@
 module ARStateMachine
-  VERSION = "0.3.7"
+  VERSION = "0.3.8"
 end

--- a/spec/lib/state_machine_spec.rb
+++ b/spec/lib/state_machine_spec.rb
@@ -143,6 +143,29 @@ describe "StateMachine" do
     expect(test.second_state_at).to eq(was)
   end
 
+  it "test overwriting timestamps with skipped_transitions" do
+    test = StateMachineTestClass.create
+    expect(test.second_state_at).to be_nil
+    expect(test.make_second_state).to be true
+    expect(test.second_state_at).not_to eq(nil)
+
+    was = test.second_state_at
+    Timecop.travel(Time.now + 2)
+
+    test.state = StateMachineTestClass::FIRST_STATE
+    expect(test.reset).to eq(StateMachineTestClass::FIRST_STATE)
+    expect(test.make_second_state).to be true
+    expect(test.second_state_at).not_to eq(was)
+
+    was = test.second_state_at
+    test.overwrite_second_state_at = false
+
+    Timecop.travel(Time.now + 2)
+    test.skipped_transition = StateMachineTestClass::SECOND_STATE
+    expect(test.make_third_state).to be true
+    expect(test.second_state_at).to eq(was)
+  end
+
   it "test overwriting ids" do
     test = StateMachineTestClass.create
     expect(test.second_state_by_id).to be_nil


### PR DESCRIPTION
Seemingly when we skip transitions we've been overwriting the `_at` col. ie: `completed -> checked (SKIPPED) -> CC Hold` very funny very silly we haven't noticed it till now