### PR TITLE
Update ar_state_machine.rb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ar_state_machine (0.3.8)
+    ar_state_machine (0.3.9)
       activerecord (>= 5.2)
       timecop
 

--- a/lib/ar_state_machine.rb
+++ b/lib/ar_state_machine.rb
@@ -91,7 +91,10 @@ module ARStateMachine
 
     if self.skipped_transition &&
        self.respond_to?("#{self.skipped_transition}_at=") &&
-       should_overwrite_timestamp?(self.skipped_transition)
+       (
+         self.respond_to?("#{self.skipped_transition}_at").blank? ||
+         should_overwrite_timestamp?(self.skipped_transition)
+       )
       self.send("#{self.skipped_transition}_at=", Time.now)
     end
 

--- a/lib/ar_state_machine/version.rb
+++ b/lib/ar_state_machine/version.rb
@@ -1,3 +1,3 @@
 module ARStateMachine
-  VERSION = "0.3.8"
+  VERSION = "0.3.9"
 end


### PR DESCRIPTION
If the skip state timestamp is blank. We still want to set it!