### PR TITLE
should_log_state_change=false Fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,40 +1,42 @@
 PATH
   remote: .
   specs:
-    ar_state_machine (0.4.0)
+    ar_state_machine (0.4.1)
       activerecord (>= 5.2)
       timecop
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.1.1)
-      activesupport (= 7.1.1)
-    activerecord (7.1.1)
-      activemodel (= 7.1.1)
-      activesupport (= 7.1.1)
+    activemodel (7.2.2)
+      activesupport (= 7.2.2)
+    activerecord (7.2.2)
+      activemodel (= 7.2.2)
+      activesupport (= 7.2.2)
       timeout (>= 0.4.0)
-    activesupport (7.1.1)
+    activesupport (7.2.2)
       base64
+      benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
-    base64 (0.1.1)
-    bigdecimal (3.1.4)
-    concurrent-ruby (1.2.2)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.2.0)
+    benchmark (0.3.0)
+    bigdecimal (3.1.8)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     diff-lcs (1.5.0)
-    drb (2.1.1)
-      ruby2_keywords
-    i18n (1.14.1)
+    drb (2.2.1)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    minitest (5.20.0)
-    mutex_m (0.1.2)
+    logger (1.6.1)
+    minitest (5.25.1)
     rake (13.0.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -49,9 +51,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    ruby2_keywords (0.0.5)
-    timecop (0.9.8)
-    timeout (0.4.0)
+    securerandom (0.3.1)
+    timecop (0.9.10)
+    timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 

--- a/lib/ar_state_machine.rb
+++ b/lib/ar_state_machine.rb
@@ -23,16 +23,19 @@ module ARStateMachine
 
     after_commit      :do_state_change_do_after_commit_callbacks
 
-    before_update     :save_state_change,
-                      if: -> { ARStateMachine.configuration.should_log_state_change && (will_save_change_to_state? || skipped_transition_equals_state?) }
-
     validate          :state_machine_validation
 
     validates         :state,
                       presence: true
 
-    has_many          :state_changes, as: :source,
-                      dependent: :delete_all
+
+    if ARStateMachine.configuration.should_log_state_change
+      has_many          :state_changes, as: :source,
+                        dependent: :delete_all
+
+      before_update     :save_state_change,
+                        if: -> { will_save_change_to_state? || skipped_transition_equals_state? }
+    end
   end
 
   def self.configuration

--- a/lib/ar_state_machine/version.rb
+++ b/lib/ar_state_machine/version.rb
@@ -1,3 +1,3 @@
 module ARStateMachine
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
I've run into a couple issues using this gem and not having a StateChange class/table. 

Example error when calling destroy on an instance with a state machine:

```
NameError: Missing model class StateChange for the Audience#state_changes association. You can specify a different model class with the :class_name option.
```